### PR TITLE
Fix type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "exports": {
     ".": {
       "require": "./dist/index.umd.cjs",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./dist/types/index.d.ts"
     },
     "./src/*": "./src/*"
   },


### PR DESCRIPTION
Correctly exporting types in package.json. See a similar issue and the solution here for reference: https://github.com/microsoft/TypeScript/issues/52363

Without you get errors like


> Could not find a declaration file for module '@tato30/vue-pdf'.
'/home/ok/what/node_modules/@tato30/vue-pdf/dist/index.mjs' implicitly has an 'any' type.
There are types at '/home/ok/what/node_modules/@tato30/vue-pdf/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@tato30/vue-pdf' library may need to update its package.json or typings.ts(7016)
⚠ Error (TS7016)
