### PR TITLE
fix: check for undefined ref value in usePDF

### DIFF
--- a/src/components/usePDF.ts
+++ b/src/components/usePDF.ts
@@ -109,8 +109,12 @@ export function usePDF(src: PDFSrc | Ref<PDFSrc>,
   }
 
   if (isRef(src)) {
-    processLoadingTask(src.value)
-    watch(src, () => processLoadingTask(src.value))
+    if (src.value !== undefined)
+      processLoadingTask(src.value)
+    watch(src, () => {
+      if (src.value !== undefined)
+        processLoadingTask(src.value)
+    })
   }
   else {
     processLoadingTask(src)


### PR DESCRIPTION
Thank you for this awesome package!

For my current project I don't have the URL of a PDF at component-setup. However, I have to make the call to usePDF since it internally uses stuff that can only be used during component setup. 

When providing a ref that has no initial value its value will be `undefined`, which leads to errors because PDFJS does not expect `undefined` as the `getDocument` parameter. This PR adds checks for undefined and only runs the `processLoadingTask` if the ref value is not `undefined`.

Through the watcher action the PDF will be loaded once the ref value has been set.

If you have any questions please tag me 😄 